### PR TITLE
Correct size unit in !mempool command

### DIFF
--- a/commands/mempool.js
+++ b/commands/mempool.js
@@ -78,7 +78,7 @@ async function mempoolCommand(message, args) {
 
   // Build the message string with a code block
   const messageString = `\`\`\`
-Blockstream's mempool has ${formattedCount} TX and is ${formattedSize} MB
+Blockstream's mempool has ${formattedCount} TX and is ${formattedSize} vMB
 Total fees in mempool are ${formattedFees} BTC
 The tip of the mempool (${range01}MB) ranges between ${range0bottomMB} sat/vbyte and ${range0topMB} sat/vbyte
 ${range10}MB - ${range11}MB = ${range1bottomMB}-${range1topMB} sat/vbyte


### PR DESCRIPTION
Blockstream reports vbyte mempool size, not bytes. Caused confusion here: https://discord.com/channels/782749290219962370/1019736722583588985/1373291347569545216