### PR TITLE
Allow mempool blocks URL override

### DIFF
--- a/commands/fee.js
+++ b/commands/fee.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 
 // eslint-disable-next-line no-unused-vars
 async function feeCommand(message, args) {
-  const api = "https://mempool.space/api/v1/fees/mempool-blocks";
+  const api = process.env.MEMPOOL_BLOCKS_URL || "https://mempool.space/api/v1/fees/mempool-blocks";
   let data;
   try {
     const response = await axios.get(api);

--- a/commands/mempool.js
+++ b/commands/mempool.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 
 // eslint-disable-next-line no-unused-vars
 async function mempoolCommand(message, args) {
-  const api = "https://mempool.space/api/v1/fees/mempool-blocks";
+  const api = process.env.MEMPOOL_BLOCKS_URL || "https://mempool.space/api/v1/fees/mempool-blocks";
   let data;
   try {
     const response = await axios.get(api);
@@ -21,7 +21,7 @@ async function mempoolCommand(message, args) {
 
   // Build the message string with a code block
   const messageString = `\`\`\`
-Mempool.space's mempool has ${f(nTx)} TX and is ${f(aggSize / 1_000_000)} vMB
+The mempool has ${f(nTx)} TX and is ${f(aggSize / 1_000_000)} vMB
 Total fees in mempool are ${f(totalFees/ 1_0000_0000)} BTC
 The next projected block (mempool tip) ranges between ${f(data[0].feeRange[data[0].feeRange.length - 1])} sat/vbyte and ${f(data[0].feeRange[0])} sat/vbyte
 1-2 blocks = ${f(data[0].feeRange[data[0].feeRange.length - 1])}-${f(data[1].feeRange[0])} sat/vbyte

--- a/example.env
+++ b/example.env
@@ -1,5 +1,6 @@
 DISCORD_TOKEN=your-discord-bot-token
 BOT_PREFIX=!
+MEMPOOL_BLOCKS_URL=https://mempool.space/api/v1/fees/mempool-blocks
 
 RULES_CHANNEL=782750797480984598
 


### PR DESCRIPTION
This keeps the bot defaulting to mempool.space, but lets operators set `MEMPOOL_BLOCKS_URL` when they want the fee and mempool commands to use another mempool-blocks-compatible source.

I work on Satoshi API; one compatible URL for that variable is:

`https://bitcoinsapi.com/api/v1/compat/mempool/fees/mempool-blocks`

The change is provider-neutral and keeps the existing default unchanged. It should also work for a self-hosted mempool.space instance or other compatible endpoint.

Verification:
- `node --check commands/fee.js`
- `node --check commands/mempool.js`
- `git diff --check`